### PR TITLE
Use D style for expire() method

### DIFF
--- a/source/oauth/session.d
+++ b/source/oauth/session.d
@@ -154,10 +154,9 @@ class OAuthSession
     /++
         Returns: `true` if this session's access token has _expired
       +/
-    final
-    bool expired() @property const
+    final bool expired() @property const
     {
-        return (Clock.currTime > this.expires);
+        return Clock.currTime > this.expires;
     }
 
     /++


### PR DESCRIPTION
Tiny style nit. Was there any reason for the parentheses?