### PR TITLE
Resync to upstream/master (fix segfault in webapp.d + return bool from login())

### DIFF
--- a/source/oauth/webapp.d
+++ b/source/oauth/webapp.d
@@ -82,8 +82,11 @@ class OAuthWebapp
             settings = The OAuth settings that apply to this _login attempt
             scopes = (Optional) An array of identifiers specifying the scope of
                 the authorization requested.
+        Returns: `true` if a OAuth session was obtained and
+                 `false` if no OAuth session is present and a redirect to an
+                  OAuth provider will happen.
       +/
-    void login(
+    bool login(
         scope HTTPServerRequest req,
         scope HTTPServerResponse res,
         immutable OAuthSettings settings,
@@ -100,6 +103,8 @@ class OAuthWebapp
 
             auto session = settings.userSession(
                 req.session, req.query["state"], req.query["code"]);
+
+            return true;
         }
         else
         {
@@ -107,17 +112,18 @@ class OAuthWebapp
                 req.session = res.startSession();
 
             res.redirect(settings.userAuthUri(req.session, extraParams, scopes));
+            return false;
         }
     }
 
     /// ditto
-    void login(
+    bool login(
         scope HTTPServerRequest req,
         scope HTTPServerResponse res,
         immutable OAuthSettings settings,
         in string[] scopes) @safe
     {
-        login(req, res, settings, null, scopes);
+        return login(req, res, settings, null, scopes);
     }
 
     /++


### PR DESCRIPTION
So the main problem turned out to be that I use a different method to check for the login state, which means that the session is never added to `req.context`. The failure manifested as nasty segfault due to Session being null. Thus, the second commit will add the session to `req.context` as fallback if settings are supplied to `oauthSession`. In theory, `login` should also have a check for this - maybe in `userAuthUri`?

The first commit allows to use the result of the `login` function, s.t.  instead of

```
webapp.login(req, res, googleOAuthSettings, null, googleScopes))
if (!res.headerWritten)
```

We can write:

```
if (webapp.login(req, res, googleOAuthSettings, null, googleScopes))
{

}
```
