### PR TITLE
enable coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,15 +1,2 @@
-codecov:
-  notify:
-    after_n_builds: 1
-
-coverage:
-  precision: 3
-  round: down
-  range: 80...100
-
-  status:
-    project: true
-    patch: true
-    changes: true
-
+# Learn more at http://docs.codecov.io/docs/codecov-yaml
 comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: d
 
 matrix:
   include:
-    # 2.078.1-beta.1 needed for coverage fix (Issue 13742)
-    - d: dmd-beta
+    - d: dmd
       script:
         - dub test -b unittest-cov
         - dub build -b ddox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: d
 
 matrix:
   include:
-    - d: dmd
+    # 2.078.1-beta.1 needed for coverage fix (Issue 13742)
+    - d: dmd-beta
       script:
-        # requires fix for Issue 13742
-        - dub test #-b unittest-cov
+        - dub test -b unittest-cov
         - dub build -b ddox
       env:
         # travis encrypt -r thaven/oauth GH_TOKEN=123456789abcdef


### PR DESCRIPTION
- coverage linkage issue is resolved in 2.078.1-beta.1
- use simpler default codecov config and only disable comments