### PR TITLE
Explicitly set dmd version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: d
 
 matrix:
   include:
-    - d: dmd
+    - d: dmd-2.078.3
       script:
         - dub test -b unittest-cov
         - dub build -b ddox


### PR DESCRIPTION
This should prevent ci errors that are not actually related to a PR from happening, as far as they're related to dmd version.