### PR TITLE
Make form POST without chunked

### DIFF
--- a/source/oauth/session.d
+++ b/source/oauth/session.d
@@ -432,8 +432,7 @@ class OAuthSession
                 {
                     import vibe.http.common : HTTPMethod;
                     req.method = HTTPMethod.POST;
-                    req.contentType = "application/x-www-form-urlencoded";
-                    req.bodyWriter.write(params.formEncode());
+                    req.writeFormBody(params);
                 }
             },
             delegate void(scope HTTPClientResponse res) {


### PR DESCRIPTION
Add `Content-Length` header and thus make the request not chunked. Chunked requests are not accepted by some OAuth servers, including ones Django or WSGI in general based. By the way, the code is simplified.

More specifically, I replaced `req.bodyWriter.write()` by `req.writeFormBody()`.

The new code with tested together with Django and now it really works.