### PR TITLE
Dependency versions update

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -29,7 +29,7 @@
           "postBuildCommands": ["rm ut.d"],
           "mainSourceFile": "ut.d",
           "dependencies": {
-              "unit-threaded": "~>0.7.11"
+              "unit-threaded": ">=0.7.11"
           }
       }
   ],

--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,7 @@
   ],
   "targetType" : "library",
   "dependencies" : {
-    "vibe-d:core" : "~>0.8.0-beta.6",
+    "vibe-d:core" : ">=0.8.0-beta.6 <0.10.0",
     "vibe-d:data" : "*",
     "vibe-d:http" : "*",
     "vibe-d:web" : {


### PR DESCRIPTION
Prevents unresolvable dependencies like:
```
Unresolvable dependencies to package unit-threaded:
  boilerplate 1.5.15 depends on unit-threaded >=0.0.0
  dshould 1.3.2 depends on unit-threaded >=0.0.0 (optional)
  dshould 1.3.2 depends on unit-threaded ~>1
  oauth 0.2.2 depends on unit-threaded ~>0.7.11
  prettyprint 1.0.6 depends on unit-threaded ~>1
  serialized 1.1.0 depends on unit-threaded >=0.0.0
```